### PR TITLE
Add suppport for gem commands in home (instead of only in the Ruby installation's bin dir)

### DIFF
--- a/libexec/rbenv-whence
+++ b/libexec/rbenv-whence
@@ -24,6 +24,19 @@ whence() {
     path="$(rbenv-prefix "$version")/bin/${command}"
     if [ -x "$path" ]; then
       [ "$print_paths" ] && echo "$path" || echo "$version"
+    else
+      gem="$(rbenv-prefix "$version")/bin/gem"
+      if [ -x "$gem" ]; then
+        OLDIFS="$IFS"
+        IFS=':' gempaths=(`$gem environment gempath`)
+        IFS="$OLDIFS"
+        for gempath in "${gempaths[@]}"; do
+          path="${gempath}/bin/${command}"
+          if [ -x "$path" ]; then
+            [ "$print_paths" ] && echo "$path" || echo "$version"
+          fi
+        done
+      fi
     fi
   done
 }

--- a/libexec/rbenv-whence
+++ b/libexec/rbenv-whence
@@ -26,12 +26,14 @@ whence() {
       [ "$print_paths" ] && echo "$path" || echo "$version"
     else
       gem="$(rbenv-prefix "$version")/bin/gem"
+      ruby="$(rbenv-prefix "$version")/bin/ruby"
       if [ -x "$gem" ]; then
         OLDIFS="$IFS"
-        IFS=':' gempaths=(`$gem environment gempath`)
+        IFS=$'\n' binpaths=(`"$ruby" -e \
+          'puts Gem.path.map(&Gem.method(:bindir)).join("\n")' 2>/dev/null || true`)
         IFS="$OLDIFS"
-        for gempath in "${gempaths[@]}"; do
-          path="${gempath}/bin/${command}"
+        for binpath in "${binpaths[@]}"; do
+          path="${binpath}/${command}"
           if [ -x "$path" ]; then
             [ "$print_paths" ] && echo "$path" || echo "$version"
           fi

--- a/rbenv.d/rehash/user-gems.bash
+++ b/rbenv.d/rehash/user-gems.bash
@@ -1,0 +1,29 @@
+list_gem_dirs() {
+  local version file
+  local -a version_dirs
+  rbenv-versions --bare --skip-aliases | \
+  while read -r version; do
+    version_dirs=("${RBENV_ROOT}/versions/${version}")
+    if [ -n "$RBENV_SYSTEM_VERSIONS_DIR" ]; then
+      version_dirs+=("$RBENV_SYSTEM_VERSIONS_DIR/${version}")
+    fi
+    for version_dir in "${version_dirs[@]}"; do
+      gem="${version_dir}/bin/gem"
+      if [ -x "$gem" ]; then
+        OLDIFS="$IFS"
+        IFS=':' gempaths=(`$gem environment gempath`)
+        IFS="$OLDIFS"
+        for gempath in "${gempaths[@]}"; do
+          bindir="${gempath}/bin"
+          for file in "${bindir}/"*; do
+            echo -n "${file##*/} "
+          done
+        done
+      fi
+    done
+  done
+}
+
+binstubs="`list_gem_dirs | sort -u`"
+
+make_shims $binstubs

--- a/rbenv.d/which/user-gems.bash
+++ b/rbenv.d/which/user-gems.bash
@@ -1,0 +1,42 @@
+if [ "$RBENV_VERSION" == "system" ]; then
+  PATH="$(remove_from_path "${RBENV_ROOT}/shims")" \
+  gem=("$(command -v "gem" || true)")
+  if [ -x "$gem" ]; then
+    OLDIFS="$IFS"
+    IFS=':' gempaths=(`$gem environment gempath`)
+    IFS="$OLDIFS"
+    for gempath in "${gempaths[@]}"; do
+      path="${gempath}/bin/${RBENV_COMMAND}"
+      if [ -x "$path" ]; then
+        RBENV_COMMAND_PATHS+=("$path")
+      fi
+    done
+  fi
+else
+  gem="${RBENV_ROOT}/versions/${RBENV_VERSION}/bin/gem"
+  if [ -x "$gem" ]; then
+    OLDIFS="$IFS"
+    IFS=':' gempaths=(`$gem environment gempath`)
+    IFS="$OLDIFS"
+    for gempath in "${gempaths[@]}"; do
+      path="${gempath}/bin/${RBENV_COMMAND}"
+      if [ -x "$path" ]; then
+        RBENV_COMMAND_PATHS+=("$path")
+      fi
+    done
+  fi
+  if [ -n "$RBENV_SYSTEM_VERSIONS_DIR" ]; then
+    gem="${RBENV_SYSTEM_VERSIONS_DIR}/${RBENV_VERSION}/bin/gem"
+    if [ -x "$gem" ]; then
+      OLDIFS="$IFS"
+      IFS=':' gempaths=(`$gem environment gempath`)
+      IFS="$OLDIFS"
+      for gempath in "${gempaths[@]}"; do
+        path="${gempath}/bin/${RBENV_COMMAND}"
+        if [ -x "$path" ]; then
+          RBENV_COMMAND_PATHS+=("$path")
+        fi
+      done
+    fi
+  fi
+fi

--- a/rbenv.d/which/user-gems.bash
+++ b/rbenv.d/which/user-gems.bash
@@ -1,41 +1,40 @@
+# List all gem bindirs for specified ruby executable
+list_gem_bindirs() {
+  local ruby="$1"
+  "$ruby" -e \
+          'puts Gem.path.map(&Gem.method(:bindir)).join("\n")' 2>/dev/null || true
+}
+
 if [ "$RBENV_VERSION" == "system" ]; then
   PATH="$(remove_from_path "${RBENV_ROOT}/shims")" \
-  gem=("$(command -v "gem" || true)")
+  gem="$(command -v "gem" || true)" \
+  ruby="$(command -v "ruby" || true)"
   if [ -x "$gem" ]; then
     OLDIFS="$IFS"
-    IFS=':' gempaths=(`$gem environment gempath`)
+    IFS=$'\n' bindirs=(`list_gem_bindirs "$ruby"`)
     IFS="$OLDIFS"
-    for gempath in "${gempaths[@]}"; do
-      path="${gempath}/bin/${RBENV_COMMAND}"
-      if [ -x "$path" ]; then
-        RBENV_COMMAND_PATHS+=("$path")
-      fi
+    for bindir in "${bindirs[@]}"; do
+      RBENV_COMMAND_PATHS+=("${bindir}/${RBENV_COMMAND}")
     done
   fi
 else
   gem="${RBENV_ROOT}/versions/${RBENV_VERSION}/bin/gem"
   if [ -x "$gem" ]; then
     OLDIFS="$IFS"
-    IFS=':' gempaths=(`$gem environment gempath`)
+    IFS=$'\n' bindirs=(`list_gem_bindirs "${RBENV_ROOT}/versions/${RBENV_VERSION}/bin/ruby"`)
     IFS="$OLDIFS"
-    for gempath in "${gempaths[@]}"; do
-      path="${gempath}/bin/${RBENV_COMMAND}"
-      if [ -x "$path" ]; then
-        RBENV_COMMAND_PATHS+=("$path")
-      fi
+    for bindir in "${bindirs[@]}"; do
+      RBENV_COMMAND_PATHS+=("${bindir}/${RBENV_COMMAND}")
     done
   fi
   if [ -n "$RBENV_SYSTEM_VERSIONS_DIR" ]; then
     gem="${RBENV_SYSTEM_VERSIONS_DIR}/${RBENV_VERSION}/bin/gem"
     if [ -x "$gem" ]; then
       OLDIFS="$IFS"
-      IFS=':' gempaths=(`$gem environment gempath`)
+      IFS=$'\n' bindirs=(`list_gem_bindirs "${RBENV_SYSTEM_VERSIONS_DIR}/${RBENV_VERSION}/bin/ruby"`)
       IFS="$OLDIFS"
-      for gempath in "${gempaths[@]}"; do
-        path="${gempath}/bin/${RBENV_COMMAND}"
-        if [ -x "$path" ]; then
-          RBENV_COMMAND_PATHS+=("$path")
-        fi
+      for bindir in "${bindirs[@]}"; do
+        RBENV_COMMAND_PATHS+=("${bindir}/${RBENV_COMMAND}")
       done
     fi
   fi


### PR DESCRIPTION
This adds support for user-installed gems by looking at all directories in the gem path.

(Below is a clarification by @FooBarWidget)
`rbenv exec`, `rbenv rehash` etc. only look for gem commands in the Ruby installation's 'bin' directory. In other words, /usr/lib/rbenv/versions/xxx/bin/foo. Since a system-wide-installed Fullstaq Ruby installation is supposed to support per-user gems, it would be great if rbenv looks for gem commands in the user's home directory too (~/.gem/ruby/xxx/bin).