### PR TITLE
Remove default bindir from path list

### DIFF
--- a/libexec/rbenv-whence
+++ b/libexec/rbenv-whence
@@ -30,7 +30,7 @@ whence() {
       if [ -x "$gem" ]; then
         OLDIFS="$IFS"
         IFS=$'\n' binpaths=(`"$ruby" -e \
-          'puts Gem.path.map(&Gem.method(:bindir)).join("\n")' 2>/dev/null || true`)
+          'puts (Gem.path.map(&Gem.method(:bindir)) - [Gem.default_bindir]).join("\n")' 2>/dev/null || true`)
         IFS="$OLDIFS"
         for binpath in "${binpaths[@]}"; do
           path="${binpath}/${command}"

--- a/rbenv.d/rehash/user-gems.bash
+++ b/rbenv.d/rehash/user-gems.bash
@@ -18,7 +18,7 @@ list_executable_names() {
       gem="${version_dir}/bin/gem"
       if [ -x "$gem" ]; then
         "${version_dir}/bin/ruby" -e \
-          'puts Gem.path.map(&Gem.method(:bindir)).join("\n")' 2>/dev/null | \
+          'puts (Gem.path.map(&Gem.method(:bindir)) - [Gem.default_bindir]).join("\n")' 2>/dev/null | \
         while read -r bindir; do
           for file in "${bindir}/"*; do
             [ -x "$file" ] && echo "${file##*/}"

--- a/rbenv.d/which/user-gems.bash
+++ b/rbenv.d/which/user-gems.bash
@@ -2,7 +2,7 @@
 list_gem_bindirs() {
   local ruby="$1"
   "$ruby" -e \
-          'puts Gem.path.map(&Gem.method(:bindir)).join("\n")' 2>/dev/null || true
+          'puts (Gem.path.map(&Gem.method(:bindir)) - [Gem.default_bindir]).join("\n")' 2>/dev/null || true
 }
 
 if [ "$RBENV_VERSION" == "system" ]; then


### PR DESCRIPTION
When using system-wide rubies, it is possible that a system location is
included in the list. E.g. `/usr/bin` or `/usr/local/bin`. This in turn
results in rbenv shims for all binaries in there, possibly causing
an infinite loop. The problematic location is always the default bindir.